### PR TITLE
Fix for #300

### DIFF
--- a/src/utils/tty.py
+++ b/src/utils/tty.py
@@ -149,6 +149,7 @@ def show_all(args, runs, archConfigs, output):
                                             .astype(float)
                                             .round(args.decimal)
                                             .map(str)
+                                            .astype(str)
                                             + " ("
                                             + t_df_pretty.map(str)
                                             + "%)"


### PR DESCRIPTION
On some versions of numpy/pandas, applying a str map to an empty series doesn't change the type. As a result, when adding a float to a string, sometimes numpy dies with a uadd error. We fix this by explicitly casting to a str first