### PR TITLE
Improve logging

### DIFF
--- a/src/omniperf_profile/profiler_base.py
+++ b/src/omniperf_profile/profiler_base.py
@@ -172,12 +172,10 @@ class OmniProfiler_Base:
                 msg = "Detected differing {} values while joining pmc_perf.csv".format(
                     key
                 )
-                console_warning(msg + "\n")
+                console_warning(msg)
             else:
                 msg = "Successfully joined {} in pmc_perf.csv".format(key)
-                console_debug(msg + "\n")
-            if test_df_column_equality(_df) and self.__args.verbose:
-                console_log("profiling", msg)
+                console_debug(msg)
 
         # now, we can:
         #   A) throw away any of the "boring" duplicates

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -73,7 +73,22 @@ def setup_console_handler():
     setattr(logging, "TRACE", logging.TRACE)
     setattr(logging, "trace", trace_logger)
 
-    formatter = ColoredFormatter()
+    color_setting = 1
+    if "OMNIPERF_COLOR" in os.environ.keys():
+        if type(os.environ["OMNIPERF_COLOR"]) != int:
+            raise TypeError(
+                "OMNIPERF_COLOR must be of type int. Detected: {}".format(
+                    type(os.environ["OMNIPERF_COLOR"])
+                )
+            )
+        color_setting = int(os.environ["OMNIPERF_COLOR"])
+
+    if color_setting == 1:
+        # colored loglevel and message
+        formatter = ColoredFormatter()
+    else:
+        # non-colored
+        formatter = PlainFormatter()
 
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(formatter)

--- a/src/utils/parser.py
+++ b/src/utils/parser.py
@@ -928,7 +928,9 @@ def load_kernel_top(workload, dir):
             if file.exists():
                 tmp[id] = pd.read_csv(file)
             else:
-                console_warning("Issue loading top kernels. Check pmc_kernel_top.csv")
+                console_warning(
+                    f"Couldn't load {file.name}. This may result in missing analysis data."
+                )
         # NB: Special case for sysinfo. Probably room for improvement in this whole function design
         elif "from_csv_columnwise" in df.columns and id == 101:
             tmp[id] = workload.sys_info.transpose()
@@ -946,7 +948,9 @@ def load_kernel_top(workload, dir):
                 #   so tty could detect them and show them correctly in comparison.
                 tmp[id].columns = ["Info"]
             else:
-                console_warning("Issue loading top kernels. Check pmc_kernel_top.csv")
+                console_warning(
+                    f"Couldn't load {file.name}. This may result in missing analysis data."
+                )
     workload.dfs.update(tmp)
 
 


### PR DESCRIPTION
This PR extends the color introduced in the logging module to the rest of the log text. See an example below:
```console
$ omniperf profile -n mix -V -- ./mixbench
```
![image](https://github.com/ROCm/omniperf/assets/11466906/57181c39-968f-4af9-93af-874670b75fbe)

You'll see the default loglevel `INFO` is colored white, which matches other output and helps draw attention to warnings/errors. I've also changed Omniperf behavior s.t. colored logging is always on. You'll notice `DEBUG`, `ERROR`, and `WARNING` are the only log levels that output their type to the terminal (i.e., DEBUG: \<msg>).