### PR TITLE
packaging updates

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -83,16 +83,16 @@ jobs:
           make install
       - name: Verify expected paths
         run: |
-          test -d $INSTALL_DIR
-          test -x $INSTALL_DIR/bin/omniperf
-          test -s $INSTALL_DIR/libexec/omniperf/VERSION
-          test -s $INSTALL_DIR/libexec/omniperf/VERSION.sha
-          test -d $INSTALL_DIR/libexec/omniperf/omniperf_analyze
-          test -d $INSTALL_DIR/libexec/omniperf/omniperf_profile
-          test -d $INSTALL_DIR/libexec/omniperf/omniperf_soc
-          test -d $INSTALL_DIR/libexec/omniperf/utils
-          test -s $INSTALL_DIR/share/omniperf/sample/vcopy.cpp
-          test -d $INSTALL_DIR/share/omniperf/modulefiles
+          test -d $INSTALL_DIR/omniperf
+          test -x $INSTALL_DIR/omniperf/bin/omniperf
+          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION
+          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION.sha
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_analyze
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_profile
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
+          test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
+          test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
       - name: Query version (setting PYTHONPATH by hand)
         run: |
           export PYTHONPATH=${INSTALL_DIR}/python-libs:$PYTHONPATH

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -83,16 +83,17 @@ jobs:
           make install
       - name: Verify expected paths
         run: |
+          find $INSTALL_DIR
           test -d $INSTALL_DIR/omniperf
-          test -x $INSTALL_DIR/omniperf/bin/omniperf
-          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION
-          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION.sha
-          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_analyze
-          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_profile
-          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
-          test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
-          test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
-          test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
+          ## test -x $INSTALL_DIR/omniperf/bin/omniperf
+          ## test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION
+          ## test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION.sha
+          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_analyze
+          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_profile
+          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
+          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
+          ## test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
+          ## test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
       - name: Query version (setting PYTHONPATH by hand)
         run: |
           export PYTHONPATH=${INSTALL_DIR}/python-libs:$PYTHONPATH

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -74,8 +74,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/omniperf \
-            -DPYTHON_DEPS=${INSTALL_DIR}/python-libs \
-            -DMOD_INSTALL_PATH=${INSTALL_DIR}/modulefiles ..
+            -DPYTHON_DEPS=${INSTALL_DIR}/python-libs ..
       - name: Install
         run:  |
           cd omniperf-*
@@ -93,7 +92,7 @@ jobs:
           test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
           test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
           test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
-          ## test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
+          test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
       - name: Query version (setting PYTHONPATH by hand)
         run: |
           export PYTHONPATH=${INSTALL_DIR}/python-libs:$PYTHONPATH

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Access omniperf using modulefile
         run: |
           . /etc/profile.d/lmod.sh 
-          module use $INSTALL_DIR/share/omniperf/modulefiles
+          module use $INSTALL_DIR/omniperf/share/omniperf/modulefiles
           module load omniperf
           module list
           omniperf --version

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -6,6 +6,10 @@ on:
       - main
       - 2.x
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
   
 jobs:
   distbuild:
@@ -26,8 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.sha-mode.sha }}
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -56,8 +58,6 @@ jobs:
     env:
       INSTALL_DIR: /tmp/foo2
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.1
       - name: Access tarball
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -83,16 +83,16 @@ jobs:
           make install
       - name: Verify expected paths
         run: |
-          find $INSTALL_DIR
+          # find $INSTALL_DIR
           test -d $INSTALL_DIR/omniperf
-          ## test -x $INSTALL_DIR/omniperf/bin/omniperf
-          ## test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION
-          ## test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION.sha
-          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_analyze
-          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_profile
-          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
-          ## test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
-          ## test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
+          test -x $INSTALL_DIR/omniperf/bin/omniperf
+          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION
+          test -s $INSTALL_DIR/omniperf/libexec/omniperf/VERSION.sha
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_analyze
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_profile
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/omniperf_soc
+          test -d $INSTALL_DIR/omniperf/libexec/omniperf/utils
+          test -s $INSTALL_DIR/omniperf/share/omniperf/sample/vcopy.cpp
           ## test -d $INSTALL_DIR/omniperf/share/omniperf/modulefiles
       - name: Query version (setting PYTHONPATH by hand)
         run: |

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -83,12 +83,16 @@ jobs:
           make install
       - name: Verify expected paths
         run: |
-          test -d $INSTALL_DIR/omniperf
-          test -s $INSTALL_DIR/omniperf/VERSION
-          test -s $INSTALL_DIR/omniperf/VERSION.sha
-          test -d $INSTALL_DIR/omniperf/bin
-          test -x $INSTALL_DIR/omniperf/bin/omniperf
-          test -d $INSTALL_DIR/modulefiles/omniperf
+          test -d $INSTALL_DIR
+          test -x $INSTALL_DIR/bin/omniperf
+          test -s $INSTALL_DIR/libexec/omniperf/VERSION
+          test -s $INSTALL_DIR/libexec/omniperf/VERSION.sha
+          test -d $INSTALL_DIR/libexec/omniperf/omniperf_analyze
+          test -d $INSTALL_DIR/libexec/omniperf/omniperf_profile
+          test -d $INSTALL_DIR/libexec/omniperf/omniperf_soc
+          test -d $INSTALL_DIR/libexec/omniperf/utils
+          test -s $INSTALL_DIR/share/omniperf/sample/vcopy.cpp
+          test -d $INSTALL_DIR/share/omniperf/modulefiles
       - name: Query version (setting PYTHONPATH by hand)
         run: |
           export PYTHONPATH=${INSTALL_DIR}/python-libs:$PYTHONPATH
@@ -98,7 +102,7 @@ jobs:
       - name: Access omniperf using modulefile
         run: |
           . /etc/profile.d/lmod.sh 
-          module use $INSTALL_DIR/modulefiles
+          module use $INSTALL_DIR/share/omniperf/modulefiles
           module load omniperf
           module list
           omniperf --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,44 +281,58 @@ add_test(
 # Install
 # ---------
 
-# top-level driver and associated .py files
-install(PROGRAMS src/omniperf TYPE BIN)
-install(FILES src/argparser.py TYPE BIN)
-install(FILES src/config.py TYPE BIN)
-install(FILES src/omniperf_base.py TYPE BIN)
-install(FILES src/roofline.py TYPE BIN)
-
-install(FILES VERSION VERSION.sha DESTINATION ${CMAKE_INSTALL_PREFIX})
+# top-level omniperf utility
+install(PROGRAMS src/omniperf DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+# support files and version info
+install(FILES src/argparser.py src/config.py src/omniperf_base.py src/roofline.py VERSION
+              VERSION.sha DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
 # src/omniperf_analyze
 install(
     DIRECTORY src/omniperf_analyze
-    TYPE BIN
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     PATTERN src/omniperf_analyze/tests EXCLUDE
     PATTERN "__pycache__" EXCLUDE)
 # src/utils
 install(
     DIRECTORY src/utils
-    TYPE BIN
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     PATTERN "rooflines*" EXCLUDE
     PATTERN "__pycache__" EXCLUDE)
 # src/utils/rooflines
 file(GLOB rooflinebins src/utils/rooflines/roofline-*)
-install(PROGRAMS ${rooflinebins} DESTINATION ${CMAKE_INSTALL_BINDIR}/utils/rooflines)
+install(PROGRAMS ${rooflinebins} DESTINATION ${CMAKE_INSTALL_BINDIR})
 # src/omniperf_soc
 install(
     DIRECTORY src/omniperf_soc
-    TYPE BIN
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     PATTERN "__pycache__" EXCLUDE)
 # src/omniperf_profile
 install(
     DIRECTORY src/omniperf_profile
-    TYPE BIN
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     PATTERN "__pycache__" EXCLUDE)
 # samples
-install(DIRECTORY sample TYPE DATA)
-# modulefile install( FILES
-# ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-# DESTINATION ${MOD_INSTALL_PATH}/${PROJECT_NAME})
+install(
+    DIRECTORY sample
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}
+    FILES_MATCHING
+    PATTERN "*.hip"
+    PATTERN "*.h"
+    PATTERN "*.cpp"
+    PATTERN "workloads" EXCLUDE)
+# modulefile
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
+    DESTINATION ${MOD_INSTALL_PATH}/${PROJECT_NAME})
+
+# top-level symlink for bin/omniperf
+install(
+    CODE "execute_process(
+    COMMAND bash -c \"set -e
+    cd \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}
+    ln -sf ../${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/omniperf ${CMAKE_INSTALL_BINDIR}/omniperf
+    \")")
 
 # License header update(s)
 add_custom_target(
@@ -332,15 +346,32 @@ add_custom_target(
         "src/omniperf,cmake/Dockerfile,cmake/rocm_install.sh,docker/docker-entrypoint.sh,src/omniperf_analyze/convertor/mongodb/convert"
     )
 
+# ----------
 # Packaging
-include(CPack)
-set(CPACK_GENERATOR "DEB" "RPM" "TGZ")
+# ----------
+
+message(STATUS "Packaging config...")
+set(CPACK_GENERATOR "DEB" "RPM")
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_CONTACT "https://github.com/ROCm/omniperf")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Omniperf: tool for GPU performance profiling")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "Omniperf is a performance analysis tool for profiling
+machine learning/HPC workloads running on AMD GPUs.")
 set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_PROVIDES "${PROJECT_NAME}")
 
+# dependencies
+set(PACKAGE_REQUIRES
+    "rocprofiler"
+    CACHE STRING "Package dependencies")
+message(STATUS "  package dependencies: ${PACKAGE_REQUIRES}")
+set(CPACK_RPM_PACKAGE_REQUIRES ${PACKAGE_REQUIRES})
+
+include(CPack)
 # # Source tarball set(CPACK_SOURCE_GENERATOR "TGZ") set(CPACK_SOURCE_PACKAGE_FILE_NAME
 # ${CMAKE_PROJECT_NAME}-${FULL_VERSION_STRING}) set(CPACK_SOURCE_IGNORE_FILES
 # ".*~$"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,21 @@ add_custom_target(
         "src/omniperf,cmake/Dockerfile,cmake/rocm_install.sh,docker/docker-entrypoint.sh,src/omniperf_analyze/convertor/mongodb/convert"
     )
 
+option(INSTALL_TESTS "Build test suite" OFF)
+if(INSTALL_TESTS)
+    set(TESTS_COMPONENT "tests")
+    install(
+        DIRECTORY tests
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+        FILES_MATCHING
+        PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE)
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+endif()
+message(STATUS "Install tests: ${INSTALL_TESTS}")
+
 # ----------
 # Packaging
 # ----------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,4 @@ message(STATUS "  package dependencies: ${PACKAGE_REQUIRES}")
 set(CPACK_RPM_PACKAGE_REQUIRES ${PACKAGE_REQUIRES})
 
 include(CPack)
-# # Source tarball set(CPACK_SOURCE_GENERATOR "TGZ") set(CPACK_SOURCE_PACKAGE_FILE_NAME
-# ${CMAKE_PROJECT_NAME}-${FULL_VERSION_STRING}) set(CPACK_SOURCE_IGNORE_FILES
-# ".*~$"
-# \.git/ \.github \.gitmodules \.gitignore /tests /build) include(CPack)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,11 +238,6 @@ add_test(
             ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-# add_test( NAME test_analyze_commands_serial COMMAND pytest -m "serial"
-# --junitxml=tests/test_analyze_commands_serial.xml ${COV_OPTION}
-# ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py WORKING_DIRECTORY
-# ${PROJECT_SOURCE_DIR})
-
 # ---------------------------
 # analyze workloads tests
 # ---------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,70 +55,73 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 message(STATUS "Installation path: ${CMAKE_INSTALL_PREFIX}")
 
-# Python 3 is required
-message(STATUS "Detecting Python interpreter...")
-find_package(
-    Python3 3.8
-    COMPONENTS Interpreter
-    REQUIRED)
+option(CHECK_PYTHON_DEPS "Verify necessary python dependencies" ON)
+if(CHECK_PYTHON_DEPS)
+    # Python 3 is required
+    message(STATUS "Detecting Python interpreter...")
+    find_package(
+        Python3 3.8
+        COMPONENTS Interpreter
+        REQUIRED)
 
-# Allow user-provided python search path
-if(DEFINED PYTHON_DEPS)
-    set(ENV{PYTHONPATH} "${PYTHON_DEPS}")
-    message(STATUS "Optional PYTHON_DEPS provided:")
+    # Allow user-provided python search path
+    if(DEFINED PYTHON_DEPS)
+        set(ENV{PYTHONPATH} "${PYTHON_DEPS}")
+        message(STATUS "Optional PYTHON_DEPS provided:")
+        list(APPEND CMAKE_MESSAGE_INDENT "  ")
+        message(STATUS "including ${PYTHON_DEPS} in search path")
+        list(POP_BACK CMAKE_MESSAGE_INDENT)
+    endif()
+
+    # Check required Python packages
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" pythonDeps)
+
+    message(STATUS "Checking for required Python package dependencies...")
+    set_property(GLOBAL PROPERTY pythonDepsFlag "groovy")
+
+    function(checkPythonPackage [package])
+        # mapping for non-default package names
+        set(PACKAGE ${ARGV0})
+        if(${ARGV0} STREQUAL "pyyaml")
+            set(PACKAGE "yaml")
+        endif()
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c "import ${PACKAGE}"
+            OUTPUT_QUIET ERROR_QUIET
+            RESULT_VARIABLE EXIT_CODE)
+        if(${EXIT_CODE} EQUAL 0)
+            message(STATUS "${ARGV0} = yes")
+        else()
+            message(STATUS "${ARGV0} = missing")
+            set_property(GLOBAL PROPERTY pythonDepsFlag "missing")
+        endif()
+    endfunction()
+
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
-    message(STATUS "including ${PYTHON_DEPS} in search path")
+    foreach(package IN LISTS pythonDeps)
+        # Filter out any version requirements from requirements.txt
+        string(REGEX REPLACE "[><=].*" "" package "${package}")
+        string(REPLACE "-" "_" package "${package}")
+        checkpythonpackage(${package})
+    endforeach()
     list(POP_BACK CMAKE_MESSAGE_INDENT)
-endif()
 
-# Check required Python packages
-file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/requirements.txt" pythonDeps)
-
-message(STATUS "Checking for required Python package dependencies...")
-set_property(GLOBAL PROPERTY pythonDepsFlag "groovy")
-
-function(checkPythonPackage [package])
-    # mapping for non-default package names
-    set(PACKAGE ${ARGV0})
-    if(${ARGV0} STREQUAL "pyyaml")
-        set(PACKAGE "yaml")
-    endif()
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} -c "import ${PACKAGE}"
-        OUTPUT_QUIET ERROR_QUIET
-        RESULT_VARIABLE EXIT_CODE)
-    if(${EXIT_CODE} EQUAL 0)
-        message(STATUS "${ARGV0} = yes")
+    get_property(pythonDepsInstalled GLOBAL PROPERTY pythonDepsFlag)
+    if(${pythonDepsInstalled} STREQUAL "groovy")
+        message(STATUS "OK: Python dependencies available in current environment.")
     else()
-        message(STATUS "${ARGV0} = missing")
-        set_property(GLOBAL PROPERTY pythonDepsFlag "missing")
+        message(
+            FATAL_ERROR
+                "\nNecessary Python package dependencies not found. Please install required dependencies "
+                "above using your favorite package manager. If using pip, consider running:\n"
+                "python3 -m pip install -r requirements.txt\n"
+                "at the top-level of this repository. If preparing a shared installation for "
+                "multiple users, consider adding the -t <target-dir> option to install necessary dependencies "
+                "into a shared directory, e.g.\n"
+                "python3 -m pip install -t <shared-install-path> -r requirements.txt\n"
+                "Note that the -DPYTHON_DEPS=<shared-install-path> can be used to provide an "
+                "additional search path to cmake for python packages.")
     endif()
-endfunction()
-
-list(APPEND CMAKE_MESSAGE_INDENT "  ")
-foreach(package IN LISTS pythonDeps)
-    # Filter out any version requirements from requirements.txt
-    string(REGEX REPLACE "[><=].*" "" package "${package}")
-    string(REPLACE "-" "_" package "${package}")
-    checkpythonpackage(${package})
-endforeach()
-list(POP_BACK CMAKE_MESSAGE_INDENT)
-
-get_property(pythonDepsInstalled GLOBAL PROPERTY pythonDepsFlag)
-if(${pythonDepsInstalled} STREQUAL "groovy")
-    message(STATUS "OK: Python dependencies available in current environment.")
-else()
-    message(
-        FATAL_ERROR
-            "\nNecessary Python package dependencies not found. Please install required dependencies "
-            "above using your favorite package manager. If using pip, consider running:\n"
-            "python3 -m pip install -r requirements.txt\n"
-            "at the top-level of this repository. If preparing a shared installation for "
-            "multiple users, consider adding the -t <target-dir> option to install necessary dependencies "
-            "into a shared directory, e.g.\n"
-            "python3 -m pip install -t <shared-install-path> -r requirements.txt\n"
-            "Note that the -DPYTHON_DEPS=<shared-install-path> can be used to provide an "
-            "additional search path to cmake for python packages.")
 endif()
 
 # ----------------------
@@ -365,4 +368,3 @@ message(STATUS "  package dependencies: ${PACKAGE_REQUIRES}")
 set(CPACK_RPM_PACKAGE_REQUIRES ${PACKAGE_REQUIRES})
 
 include(CPack)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,5 @@ set(CPACK_SOURCE_IGNORE_FILES
     \.gitignore
     /tests
     /build)
-include(CPack)
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,4 +406,17 @@ if(INSTALL_TESTS)
     set(CPACK_RPM_TESTS_PACKAGE_REQUIRES ${CPACK_PACKAGE_NAME})
 endif()
 
+# Source tarball
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME ${CMAKE_PROJECT_NAME}-${FULL_VERSION_STRING})
+set(CPACK_SOURCE_IGNORE_FILES
+    ".*~$"
+    \.git/
+    \.github
+    \.gitmodules
+    \.gitignore
+    /tests
+    /build)
+include(CPack)
+
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,47 +265,68 @@ add_test(
 # ---------
 
 # top-level omniperf utility
-install(PROGRAMS src/omniperf DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+install(
+    PROGRAMS src/omniperf
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main)
+# python dependency requirements
+install(
+    FILES requirements.txt
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main)
 # support files and version info
-install(FILES src/argparser.py src/config.py src/omniperf_base.py src/roofline.py VERSION
-              VERSION.sha DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+install(
+    FILES src/argparser.py src/config.py src/omniperf_base.py src/roofline.py VERSION
+          VERSION.sha
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main)
 # src/omniperf_analyze
 install(
     DIRECTORY src/omniperf_analyze
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main
     PATTERN src/omniperf_analyze/tests EXCLUDE
     PATTERN "__pycache__" EXCLUDE)
 # src/utils
 install(
     DIRECTORY src/utils
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main
     PATTERN "rooflines*" EXCLUDE
     PATTERN "__pycache__" EXCLUDE)
 # src/utils/rooflines
 file(GLOB rooflinebins src/utils/rooflines/roofline-*)
-install(PROGRAMS ${rooflinebins} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+    PROGRAMS ${rooflinebins}
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT main)
 # src/omniperf_soc
 install(
     DIRECTORY src/omniperf_soc
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main
     PATTERN "__pycache__" EXCLUDE)
 # src/omniperf_profile
 install(
     DIRECTORY src/omniperf_profile
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main
     PATTERN "__pycache__" EXCLUDE)
 # samples
 install(
     DIRECTORY sample
     DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}
+    COMPONENT main
     FILES_MATCHING
     PATTERN "*.hip"
     PATTERN "*.h"
     PATTERN "*.cpp"
     PATTERN "workloads" EXCLUDE)
 # modulefile
-install(FILES ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${OMNIPERF_FULL_VERSION}.lua
-        DESTINATION ${MOD_INSTALL_PATH})
+install(
+    FILES ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${OMNIPERF_FULL_VERSION}.lua
+    DESTINATION ${MOD_INSTALL_PATH}
+    COMPONENT main)
 
 # top-level symlink for bin/omniperf
 install(
@@ -313,7 +334,8 @@ install(
     COMMAND bash -c \"set -e
     cd \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}
     ln -sf ../${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/omniperf ${CMAKE_INSTALL_BINDIR}/omniperf
-    \")")
+    \")"
+    COMPONENT main)
 
 # License header update(s)
 add_custom_target(
@@ -327,18 +349,24 @@ add_custom_target(
         "src/omniperf,cmake/Dockerfile,cmake/rocm_install.sh,docker/docker-entrypoint.sh,src/omniperf_analyze/convertor/mongodb/convert"
     )
 
+# TEST collateral
 option(INSTALL_TESTS "Build test suite" OFF)
 if(INSTALL_TESTS)
-    set(TESTS_COMPONENT "tests")
     install(
         DIRECTORY tests
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+        COMPONENT tests
         FILES_MATCHING
         PATTERN "*.py"
         PATTERN "__pycache__" EXCLUDE)
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake
-            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+    install(
+        FILES requirements-test.txt
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+        COMPONENT tests)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake
+        COMPONENT tests
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
 endif()
 message(STATUS "Install tests: ${INSTALL_TESTS}")
 
@@ -348,7 +376,9 @@ message(STATUS "Install tests: ${INSTALL_TESTS}")
 
 message(STATUS "Packaging config...")
 set(CPACK_GENERATOR "DEB" "RPM")
-set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_NAME
+    "${PROJECT_NAME}"
+    CACHE STRING "")
 set(CPACK_PACKAGE_CONTACT "https://github.com/ROCm/omniperf")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Omniperf: tool for GPU performance profiling")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "Omniperf is a performance analysis tool for profiling
@@ -358,7 +388,12 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
-set(CPACK_RPM_PACKAGE_PROVIDES "${PROJECT_NAME}")
+set(CPACK_RPM_PACKAGE_PROVIDES "${CPACK_PACKAGE_NAME}")
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+set(CPACK_RPM_MAIN_FILE_NAME "RPM-DEFAULT")
+set(CPACK_RPM_TESTS_FILE_NAME "RPM-DEFAULT")
+set(CPACK_DEBIAN_MAIN_PACKAGE_NAME "${CPACK_PACKAGE_NAME}")
+set(CPACK_RPM_MAIN_PACKAGE_NAME "${CPACK_PACKAGE_NAME}")
 
 # dependencies
 set(PACKAGE_REQUIRES
@@ -366,5 +401,9 @@ set(PACKAGE_REQUIRES
     CACHE STRING "Package dependencies")
 message(STATUS "  package dependencies: ${PACKAGE_REQUIRES}")
 set(CPACK_RPM_PACKAGE_REQUIRES ${PACKAGE_REQUIRES})
+
+if(INSTALL_TESTS)
+    set(CPACK_RPM_TESTS_PACKAGE_REQUIRES ${CPACK_PACKAGE_NAME})
+endif()
 
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ endif()
 # ----------------------
 
 set(MOD_INSTALL_PATH
-    "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/modulefiles"
+    "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/modulefiles/${PROJECT_NAME}"
     CACHE STRING "Install path for modulefile")
 message(STATUS "Modulefile install path: ${MOD_INSTALL_PATH}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,8 @@ install(
 install(
     DIRECTORY src/utils
     TYPE BIN
-    PATTERN "rooflines*" EXCLUDE)
+    PATTERN "rooflines*" EXCLUDE
+    PATTERN "__pycache__" EXCLUDE)
 # src/utils/rooflines
 file(GLOB rooflinebins src/utils/rooflines/roofline-*)
 install(PROGRAMS ${rooflinebins} DESTINATION ${CMAKE_INSTALL_BINDIR}/utils/rooflines)
@@ -315,11 +316,9 @@ install(
     PATTERN "__pycache__" EXCLUDE)
 # samples
 install(DIRECTORY sample TYPE DATA)
-# modulefile
-install(
-    FILES
-        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-    DESTINATION ${MOD_INSTALL_PATH}/${PROJECT_NAME})
+# modulefile install( FILES
+# ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
+# DESTINATION ${MOD_INSTALL_PATH}/${PROJECT_NAME})
 
 # License header update(s)
 add_custom_target(
@@ -333,15 +332,16 @@ add_custom_target(
         "src/omniperf,cmake/Dockerfile,cmake/rocm_install.sh,docker/docker-entrypoint.sh,src/omniperf_analyze/convertor/mongodb/convert"
     )
 
-# Source tarball
-set(CPACK_SOURCE_GENERATOR "TGZ")
-set(CPACK_SOURCE_PACKAGE_FILE_NAME ${CMAKE_PROJECT_NAME}-${FULL_VERSION_STRING})
-set(CPACK_SOURCE_IGNORE_FILES
-    ".*~$"
-    \.git/
-    \.github
-    \.gitmodules
-    \.gitignore
-    /tests
-    /build)
+# Packaging
 include(CPack)
+set(CPACK_GENERATOR "DEB" "RPM" "TGZ")
+set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+# # Source tarball set(CPACK_SOURCE_GENERATOR "TGZ") set(CPACK_SOURCE_PACKAGE_FILE_NAME
+# ${CMAKE_PROJECT_NAME}-${FULL_VERSION_STRING}) set(CPACK_SOURCE_IGNORE_FILES
+# ".*~$"
+# \.git/ \.github \.gitmodules \.gitignore /tests /build) include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 # ----------------------
 
 set(MOD_INSTALL_PATH
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles"
+    "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/modulefiles"
     CACHE STRING "Install path for modulefile")
 message(STATUS "Modulefile install path: ${MOD_INSTALL_PATH}")
 
@@ -134,30 +134,15 @@ set(moduleFileTemplate "omniperf.lua.in")
 
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/${moduleFileTemplate}
-    ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-    @ONLY)
-
-# Crusher mods
-if(LOCALHOST MATCHES ".*\.crusher\.olcf\.ornl\.gov")
-    list(APPEND CMAKE_MESSAGE_INDENT "  ")
-    message(STATUS "Using crusher-specific modulefile modification")
-    file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.crusher.mod mod_additions)
-    file(
-        APPEND
-        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-        ${mod_additions})
-    list(POP_BACK CMAKE_MESSAGE_INDENT)
-endif()
+    ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${OMNIPERF_FULL_VERSION}.lua @ONLY)
 
 # Thera mods
 if(LOCALHOST MATCHES "TheraS01|.*\.thera\.amd\.com|thera-hn")
     list(APPEND CMAKE_MESSAGE_INDENT "  ")
     message(STATUS "Using thera-specific modulefile modification")
     file(READ ${PROJECT_SOURCE_DIR}/cmake/modfile.thera.mod mod_additions)
-    file(
-        APPEND
-        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-        ${mod_additions})
+    file(APPEND ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${OMNIPERF_FULL_VERSION}.lua
+         ${mod_additions})
     list(POP_BACK CMAKE_MESSAGE_INDENT)
 endif()
 
@@ -321,10 +306,8 @@ install(
     PATTERN "*.cpp"
     PATTERN "workloads" EXCLUDE)
 # modulefile
-install(
-    FILES
-        ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/modulefiles/${PROJECT_NAME}/${OMNIPERF_FULL_VERSION}.lua
-    DESTINATION ${MOD_INSTALL_PATH}/${PROJECT_NAME})
+install(FILES ${PROJECT_BINARY_DIR}/${MOD_INSTALL_PATH}/${OMNIPERF_FULL_VERSION}.lua
+        DESTINATION ${MOD_INSTALL_PATH})
 
 # top-level symlink for bin/omniperf
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 set(CMAKE_BUILD_TYPE "Release")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX
-        "/opt/apps/omniperf"
+        "/opt/rocm"
         CACHE PATH "default install path" FORCE)
 endif()
 message(STATUS "Installation path: ${CMAKE_INSTALL_PREFIX}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,9 @@ message(STATUS "Install tests: ${INSTALL_TESTS}")
 # ----------
 
 message(STATUS "Packaging config...")
-set(CPACK_GENERATOR "DEB" "RPM")
+set(CPACK_GENERATOR
+    "DEB" "RPM"
+    CACHE STRING "")
 set(CPACK_PACKAGE_NAME
     "${PROJECT_NAME}"
     CACHE STRING "")

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -89,13 +89,25 @@ def trace_logger(message, *args, **kwargs):
 
 def get_version(omniperf_home) -> dict:
     """Return Omniperf versioning info"""
-    # symantic version info
-    version = os.path.join(omniperf_home.parent, "VERSION")
-    try:
-        with open(version, "r") as file:
-            VER = file.read().replace("\n", "")
-    except EnvironmentError:
-        logging.critical("ERROR: Cannot find VERSION file at {}".format(version))
+
+    # symantic version info - note that version file(s) can reside in
+    # two locations depending on development vs formal install
+    searchDirs = [omniperf_home, omniperf_home.parent]
+    found = False
+    versionDir = None
+
+    for dir in searchDirs:
+        version = os.path.join(dir, "VERSION")
+        try:
+            with open(version, "r") as file:
+                VER = file.read().replace("\n", "")
+                found = True
+                versionDir = dir
+                break
+        except:
+            pass
+    if not found:
+        logging.error("Cannot find VERSION file at {}".format(searchDirs))
         sys.exit(1)
 
     # git version info
@@ -113,7 +125,7 @@ def get_version(omniperf_home) -> dict:
             SHA = gitQuery.stdout.decode("utf-8")
             MODE = "dev"
     else:
-        shaFile = os.path.join(omniperf_home.parent, "VERSION.sha")
+        shaFile = os.path.join(versionDir, "VERSION.sha")
         try:
             with open(shaFile, "r") as file:
                 SHA = file.read().replace("\n", "")


### PR DESCRIPTION
This PR enables use of `cpack` to accommodate building of RPM and DEB packages.  Install paths have also been updated to reflect ROCm conventions. e.g.

```
bin/  libexec/  share/
```

The primary omniperf utility is intended to be accessed from `bin/omniperf`  which is a soft link to the full python install in `libexec`, e.g. 

```
$ ls -l /tmp/omniperf/bin/omniperf 
lrwxrwxrwx 1 user group 28 Apr 18 10:35 /tmp/omniperf/bin/omniperf -> ../libexec/omniperf/omniperf*
```

Some new cmake vars introduced:
* `PACKAGE_REQUIRES`: external package dependencies (defaults to roc profiler)
* `INSTALL_TESTS`: controls whether test collateral is installed (defaults to NO)
* `CHECK_PYTHON_DEPS`: whether to check for python and associated runtime dependencies (defaults to YES)

Note that if `INSTALL_TESTS=ON`, a separate `omniperf-tests` package will be generated containing testing collateral.