### PR TITLE
Hotfixes: Adding support for new hardware

### DIFF
--- a/src/omniperf_soc/soc_base.py
+++ b/src/omniperf_soc/soc_base.py
@@ -195,10 +195,7 @@ class OmniSoC_Base:
             ):
                 self._mspec.gpu_model = "MI300X_A1"
             # We need to distinguish MI308X by peeking reported num CUs
-            elif(
-                self._mspec.cu_per_gpu == "80"
-                or "MI308X" in self.check_arch_override()
-            ):
+            elif self._mspec.cu_per_gpu == "80" or "MI308X" in self.check_arch_override():
                 self._mspec.gpu_model = "MI308X"
             else:
                 console_error(

--- a/src/omniperf_soc/soc_base.py
+++ b/src/omniperf_soc/soc_base.py
@@ -194,6 +194,12 @@ class OmniSoC_Base:
                 or "MI300X" in self.check_arch_override()
             ):
                 self._mspec.gpu_model = "MI300X_A1"
+            # We need to distinguish MI308X by peeking reported num CUs
+            elif(
+                self._mspec.cu_per_gpu == "80"
+                or "MI308X" in self.check_arch_override()
+            ):
+                self._mspec.gpu_model = "MI308X"
             else:
                 console_error(
                     "Cannot parse MI300 details from rocminfo. Please verify output or set the arch using (e.g.,) "

--- a/src/omniperf_soc/soc_gfx942.py
+++ b/src/omniperf_soc/soc_gfx942.py
@@ -69,6 +69,11 @@ class gfx942_soc(OmniSoC_Base):
         )
         # self.roofline_obj = Roofline(args, self._mspec)
 
+        # --showmclkrange is broken in MI308X, hardcode freq
+        if self._mspec.gpu_model == "MI308X":
+            self._mspec.max_mclk = 1300
+            self._mspec.cur_mclk = 1300
+
         # Set arch specific specs
         self._mspec._l2_banks = 16
         self._mspec.lds_banks_per_cu = 32

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -562,7 +562,10 @@ def total_xcds(archname, compute_partition):
     mi300a_archs = ["mi300a_a0", "mi300a_a1"]
     mi300x_archs = ["mi300x_a0", "mi300x_a1"]
     mi308x_archs = ["mi308x"]
-    if archname.lower() in mi300a_archs + mi300x_archs + mi308x_archs and compute_partition == "NA":
+    if (
+        archname.lower() in mi300a_archs + mi300x_archs + mi308x_archs
+        and compute_partition == "NA"
+    ):
         console_error("Invalid compute partition found for {}".format(archname))
     if archname.lower() not in mi300a_archs + mi300x_archs + mi308x_archs:
         return 1


### PR DESCRIPTION
This PR adds support for MI308X. Please note that `rocm-smi --showmclkrange` is currently broken for this hardware so we're hardcoding mclk until the issue is fixed. This is the same approach we take for MI100.
https://github.com/ROCm/omniperf/blob/352d1ee6993add7dfaad4be3d4cc5596cff5d228/src/omniperf_soc/soc_gfx942.py#L72-L75

To confirm backward compatibility, I've verified the changes on an mi308x node and mi300x. We can get this into mainline and the upcoming v2.0.1 release if reviewers are okay with these changes.