### PR TITLE
Work around crash when profiling multi-process/multi-GPU application

### DIFF
--- a/src/omniperf_profile/profiler_rocprof_v2.py
+++ b/src/omniperf_profile/profiler_rocprof_v2.py
@@ -48,10 +48,7 @@ class rocprof_v2_profiler(OmniProfiler_Base):
             # v2 requires output directory argument
             "-d",
             self.get_args().path + "/" + "out",
-            # v2 does not require csv extension
-            "-o",
-            fbase,
-            # v2 doen not require quotes on cmd
+            # v2 does not require quotes on cmd
             app_cmd,
         ]
         return args

--- a/src/omniperf_profile/profiler_rocprof_v2.py
+++ b/src/omniperf_profile/profiler_rocprof_v2.py
@@ -28,7 +28,6 @@ from utils.utils import (
     demarcate,
     console_log,
     replace_timestamps,
-    fixup_rocprofv2_dispatch_ids,
 )
 
 
@@ -84,7 +83,5 @@ class rocprof_v2_profiler(OmniProfiler_Base):
         if self.ready_to_profile:
             # Manually join each pmc_perf*.csv output
             self.join_prof()
-            # Correct dispatch ids
-            fixup_rocprofv2_dispatch_ids(self.get_args().path)
             # Replace timestamp data to solve a known rocprof bug
             replace_timestamps(self.get_args().path)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -292,12 +292,12 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
         )
 
         # Overwrite column to ensure unique IDs.
-        combined_results['Dispatch_ID'] = range(0, len(combined_results))
-        
+        combined_results["Dispatch_ID"] = range(0, len(combined_results))
+
         combined_results.to_csv(
             workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False
         )
-    
+
     if new_env:
         # flatten tcc for applicable mi300 input
         f = path(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -288,8 +288,12 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
 
         # Combine results into single CSV file
         combined_results = pd.concat([pd.read_csv(f) for f in results_files], ignore_index=True)
-        combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
 
+        # Overwrite column to ensure unique IDs.
+        combined_results['Dispatch_ID'] = range(0, len(combined_results))
+        
+        combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False)
+    
     if new_env:
         # flatten tcc for applicable mi300 input
         f = path(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
@@ -663,16 +667,3 @@ def set_locale_encoding():
             exit=False,
         )
         console_error(error)
-
-
-def fixup_rocprofv2_dispatch_ids(workload_dir):
-    # Workaround for rocprofv2 using 1-based dispatch indicies
-    # first read pmc_perf
-    df = pd.read_csv(workload_dir + "/pmc_perf.csv")
-    df["Dispatch_ID"] -= 1
-    df.to_csv(workload_dir + "/pmc_perf.csv", index=False)
-    # next glob for *LEVEL*.csv
-    for f in glob.glob(workload_dir + "/*LEVEL*.csv"):
-        df = pd.read_csv(f)
-        df["Dispatch_ID"] -= 1
-        df.to_csv(f, index=False)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -287,7 +287,7 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
         results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
 
         # Combine results into single CSV file
-        combined_results = pd.concat([pd.read_csv(f) for f in results_files])
+        combined_results = pd.concat([pd.read_csv(f) for f in results_files], ignore_index=True)
         combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
 
     if new_env:

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -287,12 +287,16 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
         results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
 
         # Combine results into single CSV file
-        combined_results = pd.concat([pd.read_csv(f) for f in results_files], ignore_index=True)
+        combined_results = pd.concat(
+            [pd.read_csv(f) for f in results_files], ignore_index=True
+        )
 
         # Overwrite column to ensure unique IDs.
         combined_results['Dispatch_ID'] = range(0, len(combined_results))
         
-        combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False)
+        combined_results.to_csv(
+            workload_dir + "/out/pmc_1/results_" + fbase + ".csv", index=False
+        )
     
     if new_env:
         # flatten tcc for applicable mi300 input

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -282,12 +282,13 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
                 console_error(output, exit=False)
         console_error("Profiling execution failed.")
 
-    # Get results
-    results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
+    if rocprof_cmd.endswith("v2"):
+        # rocprofv2 has separate csv files for each process
+        results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
 
-    # Combine results into single CSV file
-    combined_results = pd.concat([pd.read_csv(f) for f in results_files])
-    combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
+        # Combine results into single CSV file
+        combined_results = pd.concat([pd.read_csv(f) for f in results_files])
+        combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
 
     if new_env:
         # flatten tcc for applicable mi300 input

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -282,6 +282,13 @@ def run_prof(fname, profiler_options, workload_dir, mspec, loglevel):
                 console_error(output, exit=False)
         console_error("Profiling execution failed.")
 
+    # Get results
+    results_files = glob.glob(workload_dir + "/out/pmc_1/results_*.csv")
+
+    # Combine results into single CSV file
+    combined_results = pd.concat([pd.read_csv(f) for f in results_files])
+    combined_results.to_csv(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")
+
     if new_env:
         # flatten tcc for applicable mi300 input
         f = path(workload_dir + "/out/pmc_1/results_" + fbase + ".csv")


### PR DESCRIPTION
Omniperf invokes `rocprof` to collect profiling data. `rocprof` has a `-o` option to specify an output CSV file. In the multi-GPU case, multiple processes will try to write to this file, corrupting it.

This change removes the `-o` option when invoking `rocprof`. Instead, Omniperf scans the output directory and combines the multiple CSV files into one CSV file.

Note: this only avoids the crash that occurs when using `rocprofv2`.