### PR TITLE
Prep work for branch renaming

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: ["main"]
+    branches: [ main, amd-mainline ]
     paths:
       - 'docs/archive/docs-2.x/**'
       - 'docs/archive/docs-1.x/**'
@@ -36,7 +36,7 @@ jobs:
       - name: Build 1.x docs
         run: |
           cd docs/archive/docs-1.x
-          make html	
+          make html
       - name: Build 2.x docs
         run: |
           cd docs/archive/docs-2.x

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,9 +3,9 @@ name: Formatting
 
 on:
   push:
-    branches: [ main, dev, 2.x ]
+    branches: [ main, dev, amd-mainline, amd-staging, 2.x ]
   pull_request:
-    branches: [ main, dev, 2.x ]
+    branches: [ main, dev, amd-mainline, amd-staging, 2.x ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,9 +3,9 @@ name: Formatting
 
 on:
   push:
-    branches: [ main, dev, amd-mainline, amd-staging, 2.x ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
   pull_request:
-    branches: [ main, dev, amd-mainline, amd-staging, 2.x ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mi-rhel9.yml
+++ b/.github/workflows/mi-rhel9.yml
@@ -2,11 +2,10 @@ name: mi-rhel9
 
 on:
   push:
-    branches:
-      - 'main'
+    branches: [ main, amd-mainline ]
 
   # Allows manual execution
-  workflow_dispatch:            
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   distbuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhel-8.yml
+++ b/.github/workflows/rhel-8.yml
@@ -5,9 +5,9 @@ name: RHEL 8
 # Controls when the workflow will run
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -3,14 +3,14 @@ name: tarball
 on:
   push:
     branches:
-      - main
+      - main amd-mainline
       - 2.x
   pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   distbuild:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
             echo "sha=${{github.event.pull_request.head.sha}}" >> $GITHUB_OUTPUT
           else
             echo "sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
-          fi      
+          fi
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -101,9 +101,9 @@ jobs:
         run: sudo apt-get install -y lmod
       - name: Access omniperf using modulefile
         run: |
-          . /etc/profile.d/lmod.sh 
+          . /etc/profile.d/lmod.sh
           module use $INSTALL_DIR/omniperf/share/omniperf/modulefiles
           module load omniperf
           module list
           omniperf --version
-          
+

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -2,9 +2,7 @@ name: tarball
 
 on:
   push:
-    branches:
-      - main amd-mainline
-      - 2.x
+    branches: [ main, amd-mainline, 2.x ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -2,7 +2,7 @@ name: tarball
 
 on:
   push:
-    branches: [ main, amd-mainline, 2.x ]
+    branches: [ main, amd-mainline ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -4,9 +4,9 @@ name: Ubuntu 22.04
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, amd-mainline, amd-staging ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ and apply your changes there.
 
 - Ensure the PR is based on the `amd-staging` branch of the Omniperf GitHub repository.
 
-- Omniperf requires new commits to include a "Signed-off-by" token in the commit message (typically enabled via the `git commit -s` option), indicating your agreement to the projects's [Developer's Certificate of Origin](https://developercertificate.org/) and compatability with the project [LICENSE](https://github.com/ROCm/omniperf/blob/main/LICENSE):
+- Omniperf requires new commits to include a "Signed-off-by" token in the commit message (typically enabled via the `git commit -s` option), indicating your agreement to the projects's [Developer's Certificate of Origin](https://developercertificate.org/) and compatability with the project [LICENSE](LICENSE):
 
 
 > (a) The contribution was created in whole or in part by me and I

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 ## How to fork from us
 
-To keep our development fast and conflict free, we recommend you to [fork](https://github.com/ROCm/omniperf/fork) our repository and start your work from our `dev` branch in your private repository.
+To keep our development fast and conflict free, we recommend you to [fork](https://github.com/ROCm/omniperf/fork) our repository and start your work from our `amd-staging` branch in your private repository.
 
 Afterwards, git clone your repository to your local machine. But that is not it! To keep track of the original develop repository, add it as another remote.
 
 ```
 git remote add mainline https://github.com/ROCm/omniperf.git
-git checkout dev
+git checkout amd-staging
 ```
 
 As always in git, start a new branch with
@@ -31,7 +31,7 @@ and apply your changes there.
 
 - Ensure the PR description clearly describes the problem and solution. If there is an existing GitHub issue open describing this bug, please include it in the description so we can close it.
 
-- Ensure the PR is based on the `dev` branch of the Omniperf GitHub repository.
+- Ensure the PR is based on the `amd-staging` branch of the Omniperf GitHub repository.
 
 - Omniperf requires new commits to include a "Signed-off-by" token in the commit message (typically enabled via the `git commit -s` option), indicating your agreement to the projects's [Developer's Certificate of Origin](https://developercertificate.org/) and compatability with the project [LICENSE](https://github.com/ROCm/omniperf/blob/main/LICENSE):
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ contribution process.
 Omniperf follows a
 [main-dev](https://nvie.com/posts/a-successful-git-branching-model/)
 branching model. As a result, our latest stable release is shipped
-from the `main` branch, while new features are developed in our
+from the `amd-mainline` branch, while new features are developed in our
 `amd-staging` branch.
 
 Users may checkout `amd-staging` to preview upcoming features.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Omniperf follows a
 [main-dev](https://nvie.com/posts/a-successful-git-branching-model/)
 branching model. As a result, our latest stable release is shipped
 from the `main` branch, while new features are developed in our
-`dev` branch.
+`amd-staging` branch.
 
-Users may checkout `dev` to preview upcoming features.
+Users may checkout `amd-staging` to preview upcoming features.
 
 ## How to Cite
 


### PR DESCRIPTION
There is a Dev-Ops request to use standard branch names for our staging and main branches. This change is prep work for that.

`main` --> `amd-mainline`
`dev` --> `amd-staging`

References to branch names have been updated in the README and CONTRIBUTING documentation. 
New branch names have been added to workflows. However, old branch names will not be removed until renaming is complete.