### PR TITLE
Enable rocprofv1 for additional socs

### DIFF
--- a/src/omniperf_soc/soc_gfx940.py
+++ b/src/omniperf_soc/soc_gfx940.py
@@ -50,7 +50,7 @@ class gfx940_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/omniperf_soc/soc_gfx940.py
+++ b/src/omniperf_soc/soc_gfx940.py
@@ -50,7 +50,7 @@ class gfx940_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/omniperf_soc/soc_gfx941.py
+++ b/src/omniperf_soc/soc_gfx941.py
@@ -50,7 +50,7 @@ class gfx941_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/omniperf_soc/soc_gfx941.py
+++ b/src/omniperf_soc/soc_gfx941.py
@@ -50,7 +50,7 @@ class gfx941_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/omniperf_soc/soc_gfx942.py
+++ b/src/omniperf_soc/soc_gfx942.py
@@ -50,7 +50,7 @@ class gfx942_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {

--- a/src/omniperf_soc/soc_gfx942.py
+++ b/src/omniperf_soc/soc_gfx942.py
@@ -50,7 +50,7 @@ class gfx942_soc(OmniSoC_Base):
                     str(config.omniperf_home), "omniperf_soc", "profile_configs", "gfx940"
                 )
             )
-        self.set_compatible_profilers(["rocprofv1", "rocscope", "rocprofv2"])
+        self.set_compatible_profilers(["rocprofv1", "rocprofv2"])
         # Per IP block max number of simultaneous counters. GFX IP Blocks
         self.set_perfmon_config(
             {


### PR DESCRIPTION
Enable rocprofv1 for soc_gfx940.py, soc_gfx941.py, soc_gfx942.py.
Jira Tracking: https://ontrack-internal.amd.com/browse/SWDEV-474924