### PR TITLE
Docs housekeeping post-6.2.0

### DIFF
--- a/docs/archive/docs-1.x/index.md
+++ b/docs/archive/docs-1.x/index.md
@@ -1,5 +1,10 @@
 # Welcome to the [Omniperf](https://github.com/ROCm/omniperf) Documentation!
 
+```{warning}
+This version of the documentation is archived and contains out-of-date information.
+See [Omniperf documentation](https://rocm.docs.amd.com/projects/omniperf/en/latest/index.html) for the latest version.
+```
+
 ```eval_rst
 .. toctree::
    :glob:

--- a/docs/archive/docs-2.x/index.md
+++ b/docs/archive/docs-2.x/index.md
@@ -1,5 +1,10 @@
 # Welcome to the [Omniperf](https://github.com/ROCm/omniperf) Documentation!
 
+```{warning}
+This version of the documentation is archived and contains out-of-date information.
+See [Omniperf documentation](https://rocm.docs.amd.com/projects/omniperf/en/latest/index.html) for the latest version.
+```
+
 ```eval_rst
 .. toctree::
    :glob:

--- a/docs/how-to/analyze/cli.rst
+++ b/docs/how-to/analyze/cli.rst
@@ -186,7 +186,7 @@ Walkthrough
 
 3. Choose your own customized subset of metrics with the ``-b`` (or ``--block``)
    option. Or, build your own configuration following
-   `config_template <https://github.com/ROCm/omniperf/blob/main/src/omniperf_analyze/configs/panel_config_template.yaml>`_.
+   `config_template <https://github.com/ROCm/omniperf/blob/main/src/omniperf_soc/analysis_configs/panel_config_template.yaml>`_.
    The following snippet shows how to generate a report containing only metric 2
    (:doc:`System Speed-of-Light </conceptual/system-speed-of-light>`).
 

--- a/docs/sphinx/static/css/o_custom.css
+++ b/docs/sphinx/static/css/o_custom.css
@@ -1,30 +1,8 @@
-:root {
-    --amd-teal-500: #00C2DE;
-    --amd-teal-750: #00788E;
-}
-
 /* Override PyData Sphinx Theme default colors */
 html[data-theme='light'] {
-    --pst-color-primary: var(--amd-teal-750);
-    --pst-color-primary-bg: var(--amd-teal-500);
     --pst-color-table-row-hover-bg: #E2E8F0;
 }
 
 html[data-theme='dark'] {
-    --pst-color-primary: var(--amd-teal-500);
-    --pst-color-primary-bg: var(--amd-teal-750);
     --pst-color-table-row-hover-bg: #1E293B;
-}
-
-html[data-theme='light'],
-html[data-theme='dark'] {
-    --pst-color-link: var(--pst-color-primary);
-}
-
-a svg {
-  color: var(--pst-color-text-base);
-}
-
-a svg:hover {
-  color: var(--pst-color-link-hover);
 }


### PR DESCRIPTION
This PR
- Removes leftover css to align link colors with other ROCm component docs.
- Fixes a dead link.
- Adds a note in the archived docs pointing to the latest version.
![image](https://github.com/user-attachments/assets/7d1255f9-9232-4d45-a4a6-c23ad7ec6faf)
